### PR TITLE
Removed WP_Job_Manager class check due to changes in the main plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,3 +22,7 @@ Documentation can be found here: https://tilcode.blog/wpjm-extra-fields-adds-ext
 - Fix: Add contributor to readme.txt
 - Fix: Update readme.md with proper markdown
 - Enhancement: Added a direct link to the support forums within the Plugins page
+
+== 1.2.0 ==
+- Tested up to WordPress 5.2.4
+- Removed WP_Job_Manager class check due to changes in the main plugin

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: gma992
 Tags: job manager, job listing, job board, job management, job lists, job list, job, jobs, company, hiring, employment, employer, employees, candidate, freelance, internship, job listings, positions, board, application, hiring, listing, manager, recruiting, recruitment, talent
-Tested up to: 5.0
+Tested up to: 5.2.4
 License: GPLv2+
 
 == Description ==
@@ -30,3 +30,7 @@ No further setup is required, just install and activate the plugin under Plugins
 * Fix: Add contributor to readme.txt
 * Fix: Update readme.md with proper markdown
 * Enhancement: Added a direct link to the support forums within the Plugins page
+
+= 1.2.0 =
+* Tested up to WordPress 5.2.4
+* Removed WP_Job_Manager class check due to changes in the main plugin

--- a/wpjm-extra-fields.php
+++ b/wpjm-extra-fields.php
@@ -3,7 +3,7 @@
  * Plugin Name: WPJM Extra Fields
  * Plugin URI: https://tilcode.blog/wpjm-extra-fields-adds-extra-fields-to-wp-job-manager-job-listings
  * Description: Adds an extra Salary and Important Information fields to WP Job Manager job listings
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: Gabriel Maldonado
  * Author URI: http://tilcode.blog/
  * Text Domain: wpjm-extra-fields

--- a/wpjm-extra-fields.php
+++ b/wpjm-extra-fields.php
@@ -3,7 +3,7 @@
  * Plugin Name: WPJM Extra Fields
  * Plugin URI: https://tilcode.blog/wpjm-extra-fields-adds-extra-fields-to-wp-job-manager-job-listings
  * Description: Adds an extra Salary and Important Information fields to WP Job Manager job listings
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: Gabriel Maldonado
  * Author URI: http://tilcode.blog/
  * Text Domain: wpjm-extra-fields
@@ -19,24 +19,17 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit; 
 }
 
-if ( !class_exists( 'WP_Job_Manager' ) ) {
+add_action( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'gma_wpjmef_add_support_link_to_plugin_page' );
 
-	add_action( 'admin_notices', 'gma_wpjmef_admin_notice__error' );
-
-} else {
-
-    add_action( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'gma_wpjmef_add_support_link_to_plugin_page' );
-
-	add_filter( 'submit_job_form_fields', 'gma_wpjmef_frontend_add_salary_field');
-    add_filter( 'submit_job_form_fields', 'gma_wpjmef_frontend_add_important_info_field');
-
-    add_filter( 'job_manager_job_listing_data_fields', 'gma_wpjmef_admin_add_salary_field' );
-    add_filter( 'job_manager_job_listing_data_fields', 'gma_wpjmef_admin_add_important_info_field' );
-
-	add_action( 'single_job_listing_meta_end', 'gma_wpjmef_display_job_salary_data' );
-    add_action( 'single_job_listing_meta_end', 'gma_wpjmef_display_important_info_data' );
-
-}
+// Submit form filters
+add_filter( 'submit_job_form_fields', 'gma_wpjmef_frontend_add_salary_field');
+add_filter( 'submit_job_form_fields', 'gma_wpjmef_frontend_add_important_info_field');
+// Text fields filters
+add_filter( 'job_manager_job_listing_data_fields', 'gma_wpjmef_admin_add_salary_field' ); // #
+add_filter( 'job_manager_job_listing_data_fields', 'gma_wpjmef_admin_add_important_info_field' );
+// Single Job page filters
+add_action( 'single_job_listing_meta_end', 'gma_wpjmef_display_job_salary_data' );
+add_action( 'single_job_listing_meta_end', 'gma_wpjmef_display_important_info_data' );
 
 /**
 * Adds a direct support link under the Plugins Page once the plugin is activated


### PR DESCRIPTION
- Removing the current class check as changes in the main plugin was causing this extension to not load correctly.

- Tested up to WordPress 5.2.4